### PR TITLE
Include dependencies necessary to run camera-streaming-daemon

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -16,6 +16,8 @@ IMAGE_INSTALL += "gstreamer1.0 gst-player \
 				px4-fw \
 				mavlink-router \
 				"
+#Camera Streaming Daemon support
+IMAGE_INSTALL += "libavahi-client libavahi-glib"
 
 # Build tools
 IMAGE_INSTALL += "packagegroup-core-buildessential"


### PR DESCRIPTION
Add all missing dependencies to run camera-streaming-daemon on Aero
drones: avahi-client and avahi-glib.

A Daemon to handle camera streams on drones was published on https://github.com/01org/camera-streaming-daemon and it would be good to have all dependencies required to run it installed in Aero image.
