### PR TITLE
Updated intel-aero machine to use intel-corei7-64 from meta-intel

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -20,5 +20,6 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-openembedded/meta-oe \
   ##OEROOT##/meta-openembedded/meta-python \
   ##OEROOT##/meta-openembedded/meta-networking \
+  ##OEROOT##/meta-intel \
   "
 

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -25,7 +25,7 @@
 #MACHINE ?= "qemux86"
 #MACHINE ?= "qemux86-64"
 #
-# There are also the following hardware board target machines included for 
+# There are also the following hardware board target machines included for
 # demonstration purposes:
 #
 #MACHINE ?= "beaglebone"
@@ -83,12 +83,12 @@ TMPDIR = "${TOPDIR}/tmp"
 #
 # The distribution setting controls which policy settings are used as defaults.
 # The default value is fine for general Yocto project use, at least initially.
-# Ultimately when creating custom policy, people will likely end up subclassing 
+# Ultimately when creating custom policy, people will likely end up subclassing
 # these defaults.
 #
 DISTRO ?= "poky"
 # As an example of a subclass there is a "bleeding" edge policy configuration
-# where many versions are set to the absolute latest code from the upstream 
+# where many versions are set to the absolute latest code from the upstream
 # source control systems. This is just mentioned here as an example, its not
 # useful to most new users.
 # DISTRO ?= "poky-bleeding"
@@ -239,4 +239,3 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
-MACHINE_EXTRA_RDEPENDS += "kernel-firmware-shisp-2401a0-v21"

--- a/conf/machine/intel-aero.conf
+++ b/conf/machine/intel-aero.conf
@@ -2,13 +2,11 @@
 #@NAME: Intel Aero.
 
 #@DESCRIPTION: Machine configuration for Intel Aero Platform.
-#Based on Generic X86_64
+#Based on intel-corei7-64
 
-DEFAULTTUNE ?= "core2-64"
-require conf/machine/include/tune-core2.inc
-require conf/machine/include/genericx86-common.inc
+require conf/machine/intel-corei7-64.conf
 
+MACHINE_EXTRA_RDEPENDS += "kernel-firmware-shisp-2401a0-v21"
 MACHINE_EXTRA_RRECOMMENDS += "spidev"
 KERNEL_MODULE_AUTOLOAD += "spi_imu spi_fpga spi_can"
-CORE_IMAGE_EXTRA_INSTALL += "librealsense-graphical-examples"
 LABELS_LIVE = "install boot"

--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -56,6 +56,7 @@ GRUB_TIMEOUT = "3"
 
 # librealsense
 IMAGE_INSTALL += "librealsense"
+IMAGE_INSTALL += "librealsense-graphical-examples"
 
 addtask create_link after do_rootfs before do_image
 addtask create_os_version_file after do_rootfs before do_image


### PR DESCRIPTION
This addresses issue #42. Must be used with a manifest that includes the meta-intel layer (see manifest [PR #8](https://github.com/intel-aero/intel-aero-manifest/pull/8)). Also updated machine configuration so it only has BSP related settings.

As machine configuration has changed but name remains the same it is recommended that you build in a clean environment. Alternatively cleaning up with the following commands may enable a build, but this option has not been fully tested.
`$ bitbake airmap -c cleanall` 
`$ bitbake ros-mavlink -c cleanall` 