### PR TITLE
Created intel-aero distro based on Poky.

### DIFF
--- a/conf/distro/poky-aero.conf
+++ b/conf/distro/poky-aero.conf
@@ -1,0 +1,7 @@
+require conf/distro/poky.conf
+
+POKY_VERSION := "${DISTRO_VERSION}"
+DISTRO = "poky-aero"
+DISTRO_NAME = "Poky Aero (Intel Aero Linux Distro)"
+DISTRO_VERSION = "1.2.0"
+DISTRO_FEATURES_DEFAULT_remove = "3g"

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -25,7 +25,7 @@
 #MACHINE ?= "qemux86"
 #MACHINE ?= "qemux86-64"
 #
-# There are also the following hardware board target machines included for 
+# There are also the following hardware board target machines included for
 # demonstration purposes:
 #
 #MACHINE ?= "beaglebone"
@@ -83,12 +83,12 @@ TMPDIR = "${TOPDIR}/tmp"
 #
 # The distribution setting controls which policy settings are used as defaults.
 # The default value is fine for general Yocto project use, at least initially.
-# Ultimately when creating custom policy, people will likely end up subclassing 
+# Ultimately when creating custom policy, people will likely end up subclassing
 # these defaults.
 #
-DISTRO ?= "poky"
+DISTRO ?= "poky-aero"
 # As an example of a subclass there is a "bleeding" edge policy configuration
-# where many versions are set to the absolute latest code from the upstream 
+# where many versions are set to the absolute latest code from the upstream
 # source control systems. This is just mentioned here as an example, its not
 # useful to most new users.
 # DISTRO ?= "poky-bleeding"
@@ -220,8 +220,6 @@ BB_DISKMON_DIRS = "\
 #file://.* http://someserver.tld/share/sstate/PATH;downloadfilename=PATH \n \
 #file://.* file:///some/local/dir/sstate/PATH"
 
-# this is overloading the Poky default features
-DISTRO_FEATURES_DEFAULT = "alsa argp bluetooth ext2 irda largefile pcmcia usbgadget usbhost wifi xattr nfs zeroconf pci nfc x11"
 
 #
 # Qemu configuration


### PR DESCRIPTION
Functionality is the same as current overriden Poky design but this commit offers a place to centralize distro configuration going forward.

Variable POKY_VERSION holds the underlying Poky version (e.g. 2.1.2) and DISTRO_VERSION is set to 1.2.0 to match next planned Aero release version.

Addresses issue #97