### PR TITLE
Add back eee-acpi-scripts to handle poweroff

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -18,6 +18,9 @@ IMAGE_INSTALL += "gstreamer1.0 gst-player \
 				efibootmgr \
 				"
 
+# Handle power button through ACPI
+IMAGE_INSTALL += "eee-acpi-scripts"
+
 # Add /etc/os-release
 IMAGE_INSTALL += "os-release"
 


### PR DESCRIPTION
There was a script on eee-acpi-scripts that was handling the shutdown
button. This package got removed when we migrated to meta-intel.
Add it back.

Fix #122 