### PR TITLE
Remove opkg and opkg-utils packages

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -73,7 +73,7 @@ IMAGE_INSTALL += "autostart-supplicant"
 
 # LTE MODEM
 IMAGE_INSTALL += "glibc-gconvs glibc-utils glibc-gconv-iso8859-1 modemmanager \
-	opkg opkg-utils rpm icon-naming-utils libtool libndp libnl libinput \
+	rpm icon-naming-utils libtool libndp libnl libinput \
 	libxdmcp networkmanager autostart-modem modem-enable \
 "
 addtask create_link after do_rootfs before do_image


### PR DESCRIPTION
Removing opkg and opkg-utils packages as these packages should be
dependency from tools.

Issue: https://github.com/intel-aero/meta-intel-aero/issues/117
Signed-off-by: Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>