### PR TITLE
Bump Mavros: so it properly works with Mavlink 2.0

### DIFF
--- a/recipes-ros/mavros/libmavconn_0.18.7.bb
+++ b/recipes-ros/mavros/libmavconn_0.18.7.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "MAVLink communication library"
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=17;md5=9b511d4c606b1a23e454d3260818d003"
+
+DEPENDS = " \
+    boost \
+    ros-mavlink \
+    console-bridge \
+"
+
+RDEPENDS_${PN} = " \
+    boost \
+    ros-mavlink \
+    console-bridge \
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "libmavconn"

--- a/recipes-ros/mavros/mavros-extras_0.18.7.bb
+++ b/recipes-ros/mavros/mavros-extras_0.18.7.bb
@@ -1,0 +1,34 @@
+DESCRIPTION = "Extra nodes and plugins for <a href="http://wiki.rot.org/mavros">MAVROS</a>"
+
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=14;md5=9b511d4c606b1a23e454d3260818d003"
+
+DEFAULT_PREFERENCE = "1"
+
+MAVROS_RUN_AND_BUILD_DEPENDS = " \
+     roscpp \
+     tf2-ros \
+     tf \
+     geometry-msgs \
+     mavros-msgs \
+     sensor-msgs \
+     std-msgs \
+     visualization-msgs \
+     urdf \
+     image-transport \
+     mavros \
+ "
+
+DEPENDS = "\
+    cmake-modules \
+    cv-bridge \
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \
+"
+
+RDEPENDS_${PN} = "\
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \ 
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros_extras"

--- a/recipes-ros/mavros/mavros-msgs_0.18.7.bb
+++ b/recipes-ros/mavros/mavros-msgs_0.18.7.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "mavros_msgs defines messages for MAVROS"
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=13;md5=9b511d4c606b1a23e454d3260818d003"
+
+DEFAULT_PREFERENCE = "1"
+
+DEPENDS = " \
+    message-generation \
+    std-msgs \
+    geometry-msgs \
+"
+
+RDEPENDS_${PN} = " \
+    message-runtime \
+    std-msgs \
+    geometry-msgs \
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros_msgs"

--- a/recipes-ros/mavros/mavros.inc
+++ b/recipes-ros/mavros/mavros.inc
@@ -1,0 +1,8 @@
+SRC_URI = "https://github.com/mavlink/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "88a94aeeeda9bc8f7e5b1997071464ac"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "mavros"

--- a/recipes-ros/mavros/mavros_0.18.7.bb
+++ b/recipes-ros/mavros/mavros_0.18.7.bb
@@ -1,0 +1,50 @@
+DESCRIPTION = "MAVROS -- MAVLink extendable communication node for ROS with \
+proxy for Ground Control Station."
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=14;md5=9b511d4c606b1a23e454d3260818d003"
+DEFAULT_PREFERENCE = "1"
+
+# System dependencies
+
+DEPENDS = " \
+    boost \
+    libeigen \
+    ros-mavlink \
+"
+
+RDEPENDS_${PN} = " \
+    boost \
+    ros-mavlink \
+"
+
+# ROS packages dependencies
+MAVROS_RUN_AND_BUILD_DEPENDS = " \
+    diagnostic-updater \
+    eigen-conversions \
+    libmavconn \
+    pluginlib \
+    rosconsole-bridge \
+    roscpp \
+    tf2-ros \
+    diagnostic-msgs \
+    geometry-msgs \
+    mavros-msgs \
+    nav-msgs \
+    sensor-msgs \
+    std-msgs \
+    std-srvs \
+"
+
+DEPENDS_append = " \
+    angles \
+    cmake-modules \
+    message-runtime \
+    rospy \
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \
+"
+
+RDEPENDS_${PN}_append = "${MAVROS_RUN_AND_BUILD_DEPENDS}"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros"

--- a/recipes-ros/ros-mavlink/ros-mavlink_git.bbappend
+++ b/recipes-ros/ros-mavlink/ros-mavlink_git.bbappend
@@ -1,0 +1,9 @@
+DEPENDS += "python python-future"
+
+SRC_URI = "git://github.com/mavlink/mavlink-gbp-release.git;branch=release/kinetic/mavlink"
+
+inherit pythonnative
+
+do_configure_prepend () {
+    export PYTHONPATH="${STAGING_LIBDIR}/python2.7/site-packages/"
+}


### PR DESCRIPTION
Mavros version on meta-ros is too old and doesnt works with Mavlink 2.0
that is being used by the flight controller. Until they release a new
version of meta-ros with a more up to date mavros, we need to maintain
the recipes for this feature to work on Intel Aero.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>

---
Mavros recipes are the same as on upstream with updated version and md5 values. ros-mavlink has the same python workaround used on mavlink-router to bypass a bug on outdated meta-openembedded.

This PR also depends on PR [#5](https://github.com/intel-aero/meta-ros/pull/5) on intel-aero/meta-ros dropping the priority bumping (wont be necessary anyway).

This should address #119 and #127 