### PR TITLE
Add catkin recipe

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -35,6 +35,7 @@ IMAGE_INSTALL += "rng-tools"
 
 # Build tools
 IMAGE_INSTALL += "packagegroup-core-buildessential"
+IMAGE_INSTALL += "catkin"
 
 # Development/Debug tools
 IMAGE_INSTALL += "valgrind"


### PR DESCRIPTION
Adding catkin recipe to image so that build_tools (catkin_make) will be
available

Issue: #92
Test: Verified the availability of catkin_make in
image(path: /opt/ros/indigo/bin)

Signed-off-by: Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>