### PR TITLE
Add build-version recipe

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -62,6 +62,9 @@ IMAGE_INSTALL += "openssh-sftp-server"
 
 IMAGE_INSTALL += "hostapd"
 
+# Add build-version
+IMAGE_INSTALL += "build-version"
+
 addtask create_link after do_rootfs before do_image
 
 do_create_link() {


### PR DESCRIPTION
Created a new recipe to add firstboot-build_version.service and adding it into images recipe.

Issue: #145 