### PR TITLE
Add notify-led recipe

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -65,6 +65,9 @@ IMAGE_INSTALL += "hostapd"
 # dev-tools
 IMAGE_INSTALL += "dmidecode"
 
+# Init Scripts
+IMAGE_INSTALL += "notify-led"
+
 addtask create_link after do_rootfs before do_image
 
 do_create_link() {


### PR DESCRIPTION
notify-led recipe will enable two services which are responsible to notify boot status