### PR TITLE
Add cockpit and dependencies

### DIFF
--- a/conf/distro/poky-aero.conf
+++ b/conf/distro/poky-aero.conf
@@ -8,6 +8,9 @@ DISTRO_FEATURES_DEFAULT_remove = "3g"
 
 DISTRO_FEATURES += "aufs"
 DISTRO_FEATURES += "systemd"
+# cockpit requires pam
+DISTRO_FEATURES += "pam"
+
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"

--- a/recipes-cockpit/cockpit/cockpit-npm_142.bb
+++ b/recipes-cockpit/cockpit/cockpit-npm_142.bb
@@ -1,0 +1,70 @@
+# Recipe created by recipetool
+# This is the basis of a recipe and may need further editing in order to be fully functional.
+# (Feel free to remove these comments when editing.)
+
+# WARNING: the following LICENSE and LIC_FILES_CHKSUM values are best guesses - it is
+# your responsibility to verify that the values are complete and correct.
+#
+# NOTE: multiple licenses have been detected; they have been separated with &
+# in the LICENSE value for now since it is a reasonable assumption that all
+# of the licenses apply. If instead there is a choice between the multiple
+# licenses then you should change the value to separate the licenses with |
+# instead of &. If there is any doubt, check the accompanying documentation
+# to determine which situation is applicable.
+#
+# The following license files were not able to be identified and are
+# represented as "Unknown" below, you will need to check them yourself:
+#   COPYING.node
+#   tools/debian/copyright.template
+#   tools/debian/copyright
+#   node_modules/qunit-tap/GPL-LICENSE.txt
+#   node_modules/patternfly/LICENSE.txt
+#   node_modules/d3/LICENSE
+#   node_modules/qunitjs/LICENSE.txt
+#
+LICENSE = "LGPLv2.1 & Unknown & MIT & Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://COPYING.node;md5=efd1f7702b8f545c82eda53a8d66370f \
+                    file://tools/debian/copyright.template;md5=81adae6c924b23681adb7820e3a67483 \
+                    file://tools/debian/copyright;md5=df9002510fa96f863530013e22d6ba5b \
+                    file://src/bridge/mock-resource/system/cockpit/test/sub/COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://src/bridge/mock-resource/system/cockpit/test-priority/sub/COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://node_modules/term.js-cockpit/LICENSE;md5=2e14c05df0961c2bc6b1be030283a78f \
+                    file://node_modules/qunit-tap/GPL-LICENSE.txt;md5=2c1778696d3ba68569a0352e709ae6b7 \
+                    file://node_modules/qunit-tap/MIT-LICENSE.txt;md5=8484ee6e0e2edaebeb686297725f2ccb \
+                    file://node_modules/redux/LICENSE.md;md5=a0e9a029c575a47069a637f579057679 \
+                    file://node_modules/angular-gettext/LICENSE;md5=60e7c3f2d184ae4d83a8b355a89bc387 \
+                    file://node_modules/kubernetes-topology-graph/COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://node_modules/jquery-flot/LICENSE.txt;md5=5bc600a435aadbd7dcde045ccb3208bf \
+                    file://node_modules/patternfly/LICENSE.txt;md5=3984e2d7fa71d8d63cfd44ee8d7e801a \
+                    file://node_modules/react-lite-cockpit/LICENSE;md5=204e7ce13043865f768c3956ba96f4e5 \
+                    file://node_modules/bootstrap-datepicker/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+                    file://node_modules/c3/LICENSE;md5=4fd647cbdc543cda8a8bdf39c341f519 \
+                    file://node_modules/d3/LICENSE;md5=9a43e3ae9eeb6821b99b41158d0b08cd \
+                    file://node_modules/bootstrap/LICENSE;md5=86047de20b327af606bc29b1174c4b14 \
+                    file://node_modules/qunitjs/LICENSE.txt;md5=88e6b088e1bdb95427eca76a90663e3b \
+                    file://node_modules/angular-bootstrap-npm/LICENSE;md5=30204bcbaa0e17a488330b8a81e2292a \
+                    file://node_modules/moment/LICENSE;md5=03554c9c0d266101dd2e4b0aa8425230 \
+                    file://node_modules/registry-image-widgets/COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://node_modules/mustache/LICENSE;md5=b15e1e0022f11f78c2a3af0722e2855a \
+                    file://node_modules/kubernetes-container-terminal/COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "https://github.com/cockpit-project/cockpit/releases/download/${PV}/cockpit-${PV}.tar.xz"
+SRC_URI[md5sum] = "475d45abaa7944d4e09529423cb77acb"
+SRC_URI[sha256sum] = "34728ce97836854de0c51c8244e95a4db695454a6326b72b0f1a033406399659"
+
+# NOTE: the following prog dependencies are unknown, ignoring: krb5-config xsltproc msgcat intltool-update msgmerge msgfmt msggrep usermod intltool-merge newusers sudo ssh-agent chpasswd phantomjs chcon ssh-add intltool-extract go xmlto pkexec xgettext
+# NOTE: unable to map the following pkg-config dependencies: libssh_threads libssh
+#       (this is based on recipes that have previously been built and packaged)
+# NOTE: the following library dependencies are unknown, ignoring: ssh gssapi_krb5 pam
+#       (this is based on recipes that have previously been built and packaged)
+DEPENDS = "pcp systemd"
+
+# NOTE: if this software is not capable of being built in a separate build directory
+# from the source, you should replace autotools with autotools-brokensep in the
+# inherit line
+inherit pkgconfig gettext autotools
+
+# Specify any options you want to pass to the configure script using EXTRA_OECONF:
+EXTRA_OECONF = ""
+

--- a/recipes-cockpit/cockpit/cockpit_142.bb
+++ b/recipes-cockpit/cockpit/cockpit_142.bb
@@ -1,0 +1,37 @@
+SUMMARY = "A user interface for Linux servers"
+DESCRIPTION = "Cockpit runs in a browser and can manage your network of GNU/Linux machines"
+
+LICENSE = "LGPLv2.1 & GPLv2 & Apache-2.0 & MIT & Unknown"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://COPYING.node;md5=efd1f7702b8f545c82eda53a8d66370f"
+
+SRC_URI = "https://github.com/cockpit-project/cockpit/releases/download/${PV}/cockpit-${PV}.tar.xz"
+SRC_URI[md5sum] = "475d45abaa7944d4e09529423cb77acb"
+SRC_URI[sha256sum] = "34728ce97836854de0c51c8244e95a4db695454a6326b72b0f1a033406399659"
+
+inherit gettext pkgconfig autotools systemd
+
+#S = "${WORKDIR}/git"
+
+EXTRA_AUTORECONF = "-I tools"
+EXTRA_OECONF = "--with-cockpit-user=root --with-cockpit-group=root --disable-doc"
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} = "cockpit.service"
+
+# Avoid warnings "file XXX is owned by uid 1001, which is the same as the user running bitbake. This may be due to host contamination"
+INSANE_SKIP_${PN} += "host-user-contaminated"
+
+FILES_${PN} += "${libdir}/firewalld \
+                ${libdir}/security \
+                ${datadir}/appdata \
+                ${systemd_unitdir}/system/${PN}.socket \
+                "
+
+DEPENDS += "glib-2.0-native intltool-native"
+DEPENDS += "systemd gettext gtk+ json-glib polkit krb5 libssh libpam pcp"
+
+
+
+
+

--- a/recipes-cockpit/pcp/pcp-native_3.11.11.bb
+++ b/recipes-cockpit/pcp/pcp-native_3.11.11.bb
@@ -1,0 +1,7 @@
+require pcp.inc
+inherit native
+
+DEPENDS += "flex-native bison-native"
+
+export PCP_DIR = "${STAGING_DIR_NATIVE}"
+

--- a/recipes-cockpit/pcp/pcp.inc
+++ b/recipes-cockpit/pcp/pcp.inc
@@ -1,0 +1,26 @@
+SUMMARY = "System-level performance monitoring and performance management"
+HOMEPAGE = "http://www.pcp.io"
+SECTION =  "Applications/System"
+
+LICENSE = "GPLv2+ & LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=37ab75b580d5aad4ada04260efa3702f \
+                    "
+
+SRC_URI = "git://github.com/performancecopilot/pcp;protocol=https"
+SRC_URI += "file://0001-perl-Perl-support-is-now-optional-enabled-by-default.patch"
+SRC_URI += "file://config.linux"
+
+
+SRCREV = "a0f7d4413cf3b5dbd675441c45ddf52011de34f9"
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools-brokensep
+
+# Specify any options you want to pass to the configure script using EXTRA_OECONF:
+EXTRA_OECONF = "--without-python --without-python3 --without-perl"
+EXTRA_OEMAKE = ""
+
+do_configure_prepend() {
+    cp ${WORKDIR}/config.linux ${B}
+    export SED=${TMPDIR}/hosttools/sed
+}

--- a/recipes-cockpit/pcp/pcp.inc
+++ b/recipes-cockpit/pcp/pcp.inc
@@ -17,7 +17,8 @@ S = "${WORKDIR}/git"
 inherit pkgconfig autotools-brokensep
 
 # Specify any options you want to pass to the configure script using EXTRA_OECONF:
-EXTRA_OECONF = "--without-python --without-python3 --without-perl"
+CACHED_CONFIGUREVARS = "PACKAGE_DISTRIBUTION=arch"
+EXTRA_OECONF = "--without-python --without-python3 --without-perl --without-qt --without-qt3d"
 EXTRA_OEMAKE = ""
 
 do_configure_prepend() {

--- a/recipes-cockpit/pcp/pcp/0001-perl-Perl-support-is-now-optional-enabled-by-default.patch
+++ b/recipes-cockpit/pcp/pcp/0001-perl-Perl-support-is-now-optional-enabled-by-default.patch
@@ -1,0 +1,326 @@
+From 6750f998a2a780727cd5c48d5914e58c08694ca5 Mon Sep 17 00:00:00 2001
+From: Henry Bruce <henry.bruce@intel.com>
+Date: Wed, 7 Jun 2017 15:59:39 -0700
+Subject: [PATCH] perl: Perl support is now optional, enabled by default
+
+Signed-off-by: Henry Bruce <henry.bruce@intel.com>
+---
+ configure.ac             | 87 ++++++++++++++++++++++++++++++------------------
+ src/include/builddefs.in |  9 ++---
+ src/perl/GNUmakefile     | 14 ++++++--
+ 3 files changed, 70 insertions(+), 40 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index bfe49d4..9d925e8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2,17 +2,17 @@ dnl
+ dnl Copyright (c) 2012-2017 Red Hat.
+ dnl Copyright (c) 2008 Aconex.  All Rights Reserved.
+ dnl Copyright (c) 2000-2004,2008 Silicon Graphics, Inc.  All Rights Reserved.
+-dnl 
++dnl
+ dnl This program is free software; you can redistribute it and/or modify it
+ dnl under the terms of the GNU General Public License as published by the
+ dnl Free Software Foundation; either version 2 of the License, or (at your
+ dnl option) any later version.
+-dnl 
++dnl
+ dnl This program is distributed in the hope that it will be useful, but
+ dnl WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ dnl or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ dnl for more details.
+-dnl 
++dnl
+ 
+ dnl unpacking check - this file must exist
+ AC_INIT(src/include/pcp/pmapi.h)
+@@ -104,6 +104,12 @@ AC_ARG_WITH([qt3d],
+     [do_qt3d=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-qt3d=$withval"],
+     [do_qt3d=check])
+ 
++AC_ARG_WITH([perl],
++    [AC_HELP_STRING([--with-perl],
++                    [enable support for tools requiring Perl (default is on)])],
++    [do_perl=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-perl=$withval"],
++    [do_perl=check])
++
+ AC_ARG_WITH([python],
+     [AC_HELP_STRING([--with-python],
+                     [enable support for tools requiring Python (default is on)])],
+@@ -231,7 +237,7 @@ else
+     build_os=`echo $build_os | sed '[s/^\([^-][^-]*\)-.*$/\1/]'`
+ fi
+ 
+-echo Building on $build for $target 
++echo Building on $build for $target
+ echo "Build: os=$build_os cpu=$build_cpu"
+ echo "Target: os=$target_os cpu=$target_cpu"
+ 
+@@ -916,18 +922,33 @@ dnl check if perl available for the build and runtime
+ AC_CHECK_PROGS(PERL, perl)
+ AC_SUBST(PERL)
+ 
+-AC_MSG_CHECKING([for any perl version])
+-if test "$cross_compiling" = "yes"; then
+-    ans=$have_perl
+-    echo "cross-compile -> \"$ans\"" >&5
+-elif test -n "$PERL"
+-then
+-    pcp_perl_prog=$PERL
+-    have_perl=true
+-else
+-    pcp_perl_prog=""
+-    have_perl=false
+-fi
++dnl check if perl tools/packages wanted
++enable_perl=false
++AS_IF([test "x$do_perl" != "xno"], [
++    enable_perl=true
++    if test -z "$PERL"
++    then
++        enable_perl=false
++    else
++        AC_MSG_CHECKING([for any perl version])
++        if test "$cross_compiling" = "yes"; then
++            ans=$have_perl
++            echo "cross-compile -> \"$ans\"" >&5
++        elif test -n "$PERL"
++        then
++            pcp_perl_prog=$PERL
++            have_perl=true
++        else
++            pcp_perl_prog=""
++            have_perl=false
++        fi
++        if test "$do_perl" != "check" -a "$enable_perl" != "true"
++        then
++            AC_MSG_ERROR([cannot enable Perl - no supported version found])
++        fi
++    fi
++])
++AC_SUBST(enable_perl)
+ AC_SUBST(pcp_perl_prog)
+ AC_SUBST(have_perl)
+ AC_MSG_RESULT($pcp_perl_prog)
+@@ -1117,7 +1138,7 @@ qt_release=release
+ qt_version=0
+ AS_IF([test "x$do_qt" != "xno"], [
+     enable_qt=true
+-    
++
+     if test -z "$QMAKE"
+     then
+ 	AC_PATH_PROGS(QMAKE, [qmake-qt5 qmake-qt4 qmake],, [$QTDIR/bin:/usr/bin:/usr/lib64/qt5/bin:/usr/lib/qt5/bin:/usr/lib64/qt4/bin:/usr/lib/qt4/bin:/usr/local/bin])
+@@ -1181,7 +1202,7 @@ dnl note: all makefiles in this package use the gmake syntax
+ if test -z "$MAKE"
+ then
+     AC_PATH_PROG(MAKE, gmake)
+-    if test -z "$MAKE" 
++    if test -z "$MAKE"
+     then
+ 	# look elsewhere ...
+ 	AC_MSG_CHECKING([for GNU make elsewhere])
+@@ -1210,7 +1231,7 @@ then
+ 	    fi
+ 	fi
+ 	AC_MSG_RESULT($MAKE)
+-    fi 
++    fi
+ fi
+ make=$MAKE
+ AC_SUBST(make)
+@@ -1333,7 +1354,7 @@ then
+ 	    AC_MSG_WARN([PackageMaker not found, mac packages will not be made])
+ 	fi
+     else
+-	AC_MSG_RESULT([ no])	
++	AC_MSG_RESULT([ no])
+     fi
+ else
+     package_maker="$PACKAGE_MAKER"
+@@ -1576,8 +1597,8 @@ AC_CHECK_HEADERS(sys/statvfs.h sys/statfs.h sys/mount.h)
+ dnl Check if we have <sys/endian.h> ... standard way
+ AC_MSG_CHECKING([for sys/endian.h ])
+ AC_TRY_COMPILE(
+-[  
+-    #include <sys/endian.h> 
++[
++    #include <sys/endian.h>
+ ],
+ [
+ ], AC_DEFINE(HAVE_SYS_ENDIAN_H, [1], [sys/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
+@@ -1585,8 +1606,8 @@ AC_TRY_COMPILE(
+ dnl Check if we have <machine/endian.h> ... MacOSX way
+ AC_MSG_CHECKING([for machine/endian.h ])
+ AC_TRY_COMPILE(
+-[  
+-    #include <machine/endian.h> 
++[
++    #include <machine/endian.h>
+ ],
+ [
+ ], AC_DEFINE(HAVE_MACHINE_ENDIAN_H, [1], [machine/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
+@@ -1594,9 +1615,9 @@ AC_TRY_COMPILE(
+ dnl Check if we have <sys/endian.h> ... IRIX strangeness
+ AC_MSG_CHECKING([for sys/endian.h (IRIX variant) ])
+ AC_TRY_COMPILE(
+-[  
++[
+     #include <standards.h>
+-    #include <sys/endian.h> 
++    #include <sys/endian.h>
+ ],
+ [
+ ], AC_DEFINE(HAVE_SYS_ENDIAN_H, [1], [IRIX sys/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
+@@ -1919,9 +1940,9 @@ fi
+ dnl check if we have a type for the pointer's size integer (__psint_t)
+ AC_MSG_CHECKING([for __psint_t ])
+ AC_TRY_COMPILE(
+-[  
++[
+     #include <sys/types.h>
+-    #include <stdlib.h> 
++    #include <stdlib.h>
+     #include <stddef.h>
+ ], [ __psint_t psint; ],
+ AC_DEFINE(HAVE___PSINT_T, [1], [__psint_t type]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
+@@ -2368,7 +2389,7 @@ then
+     AC_MSG_CHECKING([where pthread_create() is defined])
+     for cand in "" pthreads pthread ; do
+ 	savedLIBS=$LIBS
+-	if test -n "$cand" 
++	if test -n "$cand"
+ 	then
+ 	    LIBS=`echo $LIBS -l$cand`
+ 	fi
+@@ -2766,7 +2787,7 @@ AC_TRY_LINK([#include <sys/wait.h>],
+ ], AC_DEFINE(HAVE_WAIT_INCLUDES_SIGNAL, [1], [indirect signal.h]))
+ 
+ dnl check for name and type of time fields in struct stat
+-dnl IRIX example	timespec_t st_mtim;	
++dnl IRIX example	timespec_t st_mtim;
+ dnl Linux example 	struct timespec st_mtim;
+ dnl Darwin example 	struct timespec st_mtimespec;
+ dnl Solaris example	timestruc_t st_mtim;
+@@ -3091,7 +3112,7 @@ AC_ARG_WITH(demosdir,[AC_HELP_STRING([--with-demosdir],[run directory [DATADIR/p
+                    [pcp_demos_dir=$pcp_share_dir/demos])
+ AC_SUBST(pcp_demos_dir)
+ 
+-if test -z "$XCONFIRM" 
++if test -z "$XCONFIRM"
+ then
+     AC_PATH_PROG(ac_xconfirm_prog, xconfirm, $pcp_bin_dir/pmconfirm)
+ else
+@@ -3275,7 +3296,7 @@ AC_TRY_COMPILE([
+ ], [ struct timespec foo; ],
+ AC_DEFINE(HAVE_STRUCT_TIMESPEC, [1], [timespec type]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
+ 
+-dnl check if we have IRIX style altzone 
++dnl check if we have IRIX style altzone
+ AC_MSG_CHECKING([for altzone in time.h])
+ AC_TRY_COMPILE([
+     #include <time.h>
+@@ -3344,7 +3365,7 @@ AC_SUBST(HAVE_ZLIB, [$have_zlib])
+ dnl Check if we have AI_ADDRCONFIG
+ AC_MSG_CHECKING([for AI_ADDRCONFIG])
+ AC_TRY_COMPILE(
+-[  
++[
+     #include <netdb.h>
+     int test = AI_ADDRCONFIG;
+ ],
+diff --git a/src/include/builddefs.in b/src/include/builddefs.in
+index 76b745e..68c0b78 100644
+--- a/src/include/builddefs.in
++++ b/src/include/builddefs.in
+@@ -2,17 +2,17 @@
+ # Copyright (c) 2012-2017 Red Hat.
+ # Copyright (c) 2008 Aconex.  All Rights Reserved.
+ # Copyright (c) 2000,2003,2004 Silicon Graphics, Inc.  All Rights Reserved.
+-# 
++#
+ # This program is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by the
+ # Free Software Foundation; either version 2 of the License, or (at your
+ # option) any later version.
+-# 
++#
+ # This program is distributed in the hope that it will be useful, but
+ # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ # for more details.
+-# 
++#
+ 
+ # Common gmake macros for building
+ #
+@@ -241,6 +241,7 @@ ENABLE_PROBES = @enable_probes@
+ ENABLE_AVAHI = @enable_avahi@
+ ENABLE_QT = @enable_qt@
+ ENABLE_QT3D = @enable_qt3d@
++ENABLE_PERL = @enable_perl@
+ ENABLE_PYTHON2 = @enable_python2@
+ ENABLE_PYTHON3 = @enable_python3@
+ ENABLE_SYSTEMD = @enable_systemd@
+@@ -753,7 +754,7 @@ PYTHON3_INSTALL = \
+ 	fi
+ else
+ # default case if all of the above tests fail
+-PYTHON_INSTALL = 
++PYTHON_INSTALL =
+ endif	# openbsd if
+ endif	# cocoa ... freebsd if
+ endif	# linux && !gentoo if
+diff --git a/src/perl/GNUmakefile b/src/perl/GNUmakefile
+index be4ba95..ddabcb4 100644
+--- a/src/perl/GNUmakefile
++++ b/src/perl/GNUmakefile
+@@ -1,16 +1,16 @@
+ #
+ # Copyright (c) 2008-2009 Aconex.  All Rights Reserved.
+-# 
++#
+ # This program is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by the
+ # Free Software Foundation; either version 2 of the License, or (at your
+ # option) any later version.
+-# 
++#
+ # This program is distributed in the hope that it will be useful, but
+ # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ # for more details.
+-# 
++#
+ 
+ TOPDIR	= ../..
+ include $(TOPDIR)/src/include/builddefs
+@@ -19,9 +19,14 @@ ifeq "$(HAVE_PERL)" "true"
+ SUBDIRS	= PMDA LogSummary MMV LogImport
+ endif
+ 
++ifeq "$(ENABLE_PERL)" "true"
+ default: $(SUBDIRS)
+ 	$(SUBDIRS_MAKERULE)
++else
++default:
++endif
+ 
++ifeq "$(ENABLE_PERL)" "true"
+ install: $(SUBDIRS)
+ 	$(SUBDIRS_MAKERULE)
+ ifeq "$(shell [ '$(PACKAGE_DISTRIBUTION)' = cocoa \
+@@ -43,6 +48,9 @@ ifeq "$(shell [ '$(PACKAGE_DISTRIBUTION)' = cocoa \
+ 	    fi; \
+ 	fi
+ endif
++else
++install:
++endif
+ 
+ include $(BUILDRULES)
+ 
+-- 
+2.7.4
+

--- a/recipes-cockpit/pcp/pcp/config.linux
+++ b/recipes-cockpit/pcp/pcp/config.linux
@@ -1,0 +1,13 @@
+sizeof_int=4
+sizeof_long=4
+sizeof_pointer=8
+sizeof_suseconds_t=8
+sizeof_time_t=8
+bit_field_scheme=2100
+printf_p_prefix=0x
+printf_fmt_pid='"ld"'
+printf_fmt_int64=I64d
+have_procfs=true
+have_python=true
+have_perl=true
+strtoint64=strtoll

--- a/recipes-cockpit/pcp/pcp_3.11.11.bb
+++ b/recipes-cockpit/pcp/pcp_3.11.11.bb
@@ -18,6 +18,7 @@ export DIST_ROOT = "${D}"
 #cp ${RECIPE_SYSROOT}/usr/lib/perl/5.24.1/CORE/libperl.so ${RECIPE_SYSROOT}/usr/lib
 
 do_install_append() {
+  sed -i 's|${TMPDIR}/hosttools|${bindir}|' ${D}${sysconfdir}/pcp.conf
   rmdir ${D}/var/run/pcp
   rmdir ${D}/var/run
 }

--- a/recipes-cockpit/pcp/pcp_3.11.11.bb
+++ b/recipes-cockpit/pcp/pcp_3.11.11.bb
@@ -17,25 +17,47 @@ export DIST_ROOT = "${D}"
 # Copy perl lib
 #cp ${RECIPE_SYSROOT}/usr/lib/perl/5.24.1/CORE/libperl.so ${RECIPE_SYSROOT}/usr/lib
 
+do_install_append() {
+  rmdir ${D}/var/run/pcp
+  rmdir ${D}/var/run
+}
+
 inherit systemd
-SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 SYSTEMD_SERVICE_${PN} = "pmcd.service"
 
 FILES_${PN} += "${datadir}/bash-completion \
   ${datadir}/pcp-gui \
-  ${datadir}/perl5 \
   ${datadir}/bash-completion \
-  ${datadir}/vendor_perl \
   ${datadir}/zsh \
-  ${base_libdir}/systemd/system \
+  ${systemd_unitdir}/system/pmcd.service \
+  ${systemd_unitdir}/system/pmie.service \
+  ${systemd_unitdir}/system/pmlogger.service \
+  ${systemd_unitdir}/system/pmproxy.service \
   ${libdir}/zabbix \
   /run \
-  /run/pcp \
-  "
+ "
 
-# QA tests package
+# pcp-testsuite package
 PACKAGES =+ "${PN}-testsuite"
-SUMMARY_${PN}-testsuite = "Quality assurance test suite for Performance Co-Pilot (PCP)"
+SUMMARY_${PN}-testsuite = "Performance Co-Pilot (PCP) test suite"
+DESCRIPTION_${PN}-testsuite = "Quality assurance test suite for Performance Co-Pilot (PCP)"
 RDEPENDS_${PN}-testsuite = "${PN}"
 FILES_${PN}-testsuite = "/var/lib/pcp/testsuite"
+
+# pcp-manager package
+PACKAGES =+ "${PN}-manager"
+SUMMARY_${PN}-manager =  "Performance Co-Pilot (PCP) manager daemon"
+DESCRIPTION_${PN}-manager = "\
+An optional daemon (pmmgr) that manages a collection of pmlogger and \
+pmie daemons, for a set of discovered local and remote hosts running \
+the performance metrics collection daemon (pmcd).  It ensures these \
+daemons are running when appropriate, and manages their log rotation \
+needs.  It is an alternative to the cron-based pmlogger/pmie service \
+scripts."
+RDEPENDS_${PN}-manager = "${PN}"
+FILES_${PN}-manager = "${systemd_unitdir}/system/pmmgr.service \
+                       ${datadir}/pcp/lib/pmmgr\
+                       ${sysconfdir}/pcp/pmmgr"
+SYSTEMD_SERVICE_${PN}-manager = "pmmgr.service"
 

--- a/recipes-cockpit/pcp/pcp_3.11.11.bb
+++ b/recipes-cockpit/pcp/pcp_3.11.11.bb
@@ -1,0 +1,41 @@
+require pcp.inc
+#inherit perlnative
+#inherit python3native
+
+# NOTE: the following prog dependencies are unknown, ignoring: gtar gzip pkgmk xmlto lzma qshape md5sum pod2man publican git makedepend qmake-qt4 xconfirm true gmake xz dblatex hdiutil rpm bzip2 which mkinstallp dtrace seinfo qmake-qt5 gawk dlltool rpmbuild dpkg makepkg qmake echo
+# NOTE: unable to map the following pkg-config dependencies: libmicrohttpd libsystemd-journal
+#       (this is based on recipes that have previously been built and packaged)
+# NOTE: the following library dependencies are unknown, ignoring: nspr gen ibumad regex sasl2 pfm nss papi ibmad
+#       (this is based on recipes that have previously been built and packaged)
+DEPENDS += "bison-native flex-native pcp-native cairo zlib ncurses readline libx11 avahi openssl"
+
+EXTRA_OECONF += "--with-group=root --with-user=root"
+
+export PCP_DIR = "${BASE_WORKDIR}/${BUILD_SYS}/${PN}-native/${PV}-${PR}/recipe-sysroot-native"
+export DIST_ROOT = "${D}"
+
+# Copy perl lib
+#cp ${RECIPE_SYSROOT}/usr/lib/perl/5.24.1/CORE/libperl.so ${RECIPE_SYSROOT}/usr/lib
+
+inherit systemd
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} = "pmcd.service"
+
+FILES_${PN} += "${datadir}/bash-completion \
+  ${datadir}/pcp-gui \
+  ${datadir}/perl5 \
+  ${datadir}/bash-completion \
+  ${datadir}/vendor_perl \
+  ${datadir}/zsh \
+  ${base_libdir}/systemd/system \
+  ${libdir}/zabbix \
+  /run \
+  /run/pcp \
+  "
+
+# QA tests package
+PACKAGES =+ "${PN}-testsuite"
+SUMMARY_${PN}-testsuite = "Quality assurance test suite for Performance Co-Pilot (PCP)"
+RDEPENDS_${PN}-testsuite = "${PN}"
+FILES_${PN}-testsuite = "/var/lib/pcp/testsuite"
+


### PR DESCRIPTION
Performance co-pilot is a package required by the Cockpit Project (issue #149)
See  https://github.com/performancecopilot/pcp.
This initial check-in disables perl and python support.
pcp depends on pcp-native. pcp build will fail if pcp-native
is built from shared state. Run cleansstate task on pcp-native
to work around this problem.

@avinash-palleti I need your help to create a test plan.
@leopck, this is related to the cocpkit work we have discussed.