### PR TITLE
layer conf: Additional dir level

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -3,7 +3,9 @@ BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*.bbappend"
+            ${LAYERDIR}/recipes-*/*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend \
+            ${LAYERDIR}/recipes-*/*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "intelaero"
 BBFILE_PATTERN_intelaero = "^${LAYERDIR}/"


### PR DESCRIPTION
Allow additional recipe directory in the structure.

The expected dnf recipe was not being included in the image build.

**Alternative: git mv recipes-backport/devtools/dnf -> recipes-backport/dnf**