### PR TITLE
intel-aero-repo: Change name

### DIFF
--- a/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
+++ b/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
@@ -1,4 +1,4 @@
-[Intel Aero]
+[Main]
 name=Intel Aero
 baseurl=https://download.01.org/aero/repo/1.4/
 gpgcheck=1


### PR DESCRIPTION
It can't have whitespaces. Renamed to Main.