### PR TITLE
repo: Disabled by default

### DIFF
--- a/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
+++ b/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
@@ -2,3 +2,4 @@
 name=Intel Aero
 baseurl=https://download.01.org/aero/repo/1.4/
 gpgcheck=1
+enabled=0


### PR DESCRIPTION
Make repo disasbled by default for now.
Also avoids an issue during do_rootfs that breaks the image generation
in certain circumstances.