### PR TITLE
intel-aero-image: Use actual wget instead of the busybox one

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -12,6 +12,7 @@ inherit core-image
 
 # full version of command line tools, not the busybox ones
 IMAGE_INSTALL += "packagegroup-core-full-cmdline"
+IMAGE_INSTALL += "wget"
 
 IMAGE_INSTALL += "packagegroup-docker"
 


### PR DESCRIPTION
The full wget isn't part of packagegroup-core-full-cmdline.
The stripped down version provided by busybox does not deal with https.