### PR TITLE
rpm: Ignore signature check failure

### DIFF
--- a/recipes-devtools/rpm/files/0001-Ignore-tag-number-mismatch.patch
+++ b/recipes-devtools/rpm/files/0001-Ignore-tag-number-mismatch.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/header.c b/lib/header.c
+index ab721a5..aac6eb5 100644
+--- a/lib/header.c
++++ b/lib/header.c
+@@ -1827,7 +1827,9 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
+ 	rasprintf(buf,
+ 		_("region %d: tag number mismatch %d ril %d dl %d rdl %d\n"),
+ 		regionTag, blob->il, blob->ril, blob->dl, blob->rdl);
++#ifdef HACK
+ 	goto exit;
++#endif
+     }
+ 
+     blob->regionTag = regionTag;

--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-Ignore-tag-number-mismatch.patch"
+


### PR DESCRIPTION
Includes changes to ignore tag number mismatch.

Signed-off-by: Sugnan Prabhu S <sugnan.prabhu.s@intel.com>