### PR TITLE
rpm: Ignore signature check failure

### DIFF
--- a/recipes-devtools/rpm/files/0001-Ignore-tag-number-mismatch.patch
+++ b/recipes-devtools/rpm/files/0001-Ignore-tag-number-mismatch.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/header.c b/lib/header.c
+index ab721a5..6c1a6f9 100644
+--- a/lib/header.c
++++ b/lib/header.c
+@@ -1822,6 +1822,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
+ 	goto exit;
+     }
+ 
++#ifdef HACK
+     /* In package files region size is expected to match header size. */
+     if (exact_size && !(blob->il == blob->ril && blob->dl == blob->rdl)) {
+ 	rasprintf(buf,
+@@ -1829,6 +1830,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
+ 		regionTag, blob->il, blob->ril, blob->dl, blob->rdl);
+ 	goto exit;
+     }
++#endif
+ 
+     blob->regionTag = regionTag;
+     rc = RPMRC_OK;

--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-Ignore-tag-number-mismatch.patch"
+


### PR DESCRIPTION
Includes changes to ignore tag number mismatch.

Changes are as per the discussion with the community.
https://github.com/rpm-software-management/rpm/issues/270#issuecomment-316893255

More details on the issue:
https://github.com/intel-aero/meta-intel-aero/issues/219

Signed-off-by: Sugnan Prabhu S <sugnan.prabhu.s@intel.com>