### PR TITLE
csd: Enable Python SimpleHTTPServer

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -80,6 +80,9 @@ IMAGE_INSTALL += "initscripts-aero"
 # cockpit projects
 IMAGE_INSTALL += "cockpit"
 
+# HTTP Server
+IMAGE_INSTALL+="aero-http-server"
+
 # repo metadata
 IMAGE_INSTALL += "intel-aero-repo"
 

--- a/recipes-support/aero-http-server/aero-http-server.bb
+++ b/recipes-support/aero-http-server/aero-http-server.bb
@@ -1,0 +1,26 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+LICENSE = "GPLv2"
+LICENSE_PATH = "${S}"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+inherit systemd
+
+SRC_URI += "file://aero-http-server.sh \
+            file://aero-http-server.service \
+           " 
+ 
+
+FILES_${PN} += "${bindir}/aero-http-server.sh"
+               
+
+do_install() {
+        install -d ${D}${localstatedir}/www/hosted_files
+        install -d ${D}${systemd_unitdir}/system
+        install -d ${D}${bindir}
+        install -m 0644 ${WORKDIR}/aero-http-server.service ${D}${systemd_unitdir}/system
+        install -m 0755 ${WORKDIR}/aero-http-server.sh ${D}${bindir}
+        
+
+}
+
+SYSTEMD_SERVICE_${PN} += "aero-http-server.service"
+          

--- a/recipes-support/aero-http-server/files/aero-http-server.service
+++ b/recipes-support/aero-http-server/files/aero-http-server.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Simple HTTP Server
+Wants=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/aero-http-server.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/aero-http-server/files/aero-http-server.sh
+++ b/recipes-support/aero-http-server/files/aero-http-server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pushd /var/www/hosted_files
+/usr/bin/python -m SimpleHTTPServer


### PR DESCRIPTION
HTTP Server is required for hosting the camera definition files, images and videos.