### PR TITLE
networkmanager: fix typo in connection name

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
+++ b/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
@@ -50,4 +50,8 @@ nmcli con up modem || /bin/true
 # Make sure this script just run once
 mkdir -p $(dirname $FILECONDITION)
 touch $FILECONDITION
+
+# Let changes take effect now
+systemctl restart NetworkManager
+
 echo "First boot configuration succesful"

--- a/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
+++ b/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 FILECONDITION="/etc/sysconfig/networkmanager"
 WIFI_AP_DEFAULTPASSWORD="1234567890"
@@ -26,11 +26,11 @@ done
 
 # Let NetworkManager start dnsmasq with the right configuration file
 systemctl disable dnsmasq
-systemctl stop dnsmasq
+systemctl stop dnsmasq || /bin/true
 
-# SystemD is creating this file as symbolic link and taking care of if, not
+# systemd is creating this file as symbolic link and taking care of if, not
 # letting netowrkmanager update it with dns from modem of wifi client mode.
-rm /etc/resolv.conf
+rm /etc/resolv.conf || /bin/true
 
 # Wifi
 nmcli con add type wifi ifname '*' con-name hotspot autoconnect yes ssid $SSID
@@ -42,7 +42,7 @@ nmcli con up hotspot
 
 # Modem
 nmcli con add type gsm ifname '*' con-name modem apn $MODEM_APN_NAME autoconnect yes
-nmcli con up modem
+nmcli con up modem || /bin/true
 
 # Make sure this script just run once
 mkdir -p $(dirname $FILECONDITION)

--- a/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
+++ b/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
@@ -32,6 +32,9 @@ systemctl stop dnsmasq || /bin/true
 # letting netowrkmanager update it with dns from modem of wifi client mode.
 rm /etc/resolv.conf || /bin/true
 
+# remove all system connections
+rm /etc/NetworkManager/system-connections/* || /bin/true
+
 # Wifi
 nmcli con add type wifi ifname '*' con-name hotspot autoconnect yes ssid $SSID
 nmcli con modify hotspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared

--- a/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
+++ b/recipes-connectivity/networkmanager/networkmanager/firstboot-networkmanager-setup
@@ -33,16 +33,16 @@ systemctl stop dnsmasq
 rm /etc/resolv.conf
 
 # Wifi
-nmcli con add type wifi ifname '*' con-name Wifi-hostspot autoconnect yes ssid $SSID
-nmcli con modify Wifi-hostspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
-nmcli con modify Wifi-hostspot wifi-sec.key-mgmt wpa-psk
-nmcli con modify Wifi-hostspot wifi-sec.psk "$WIFI_AP_DEFAULTPASSWORD"
-nmcli con modify Wifi-hostspot ipv4.addresses 192.168.8.1/24
-nmcli con up Wifi-hostspot
+nmcli con add type wifi ifname '*' con-name hotspot autoconnect yes ssid $SSID
+nmcli con modify hotspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
+nmcli con modify hotspot wifi-sec.key-mgmt wpa-psk
+nmcli con modify hotspot wifi-sec.psk "$WIFI_AP_DEFAULTPASSWORD"
+nmcli con modify hotspot ipv4.addresses 192.168.8.1/24
+nmcli con up hotspot
 
 # Modem
-nmcli con add type gsm ifname '*' con-name Modem apn $MODEM_APN_NAME autoconnect yes
-nmcli con up Modem
+nmcli con add type gsm ifname '*' con-name modem apn $MODEM_APN_NAME autoconnect yes
+nmcli con up modem
 
 # Make sure this script just run once
 mkdir -p $(dirname $FILECONDITION)


### PR DESCRIPTION
Should be Hotspot, not Hostspot. Since we are changing it, let's make it
shorter