### PR TITLE
Update intel-aero-repo version using yum variables

### DIFF
--- a/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
+++ b/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
@@ -1,5 +1,0 @@
-[Main]
-name=Intel Aero
-baseurl=https://download.01.org/aero/repo/$releasever/
-gpgcheck=1
-enabled=0

--- a/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
+++ b/recipes-support/intel-aero-repo/intel-aero-repo/intel-aero.repo
@@ -1,5 +1,5 @@
 [Main]
 name=Intel Aero
-baseurl=https://download.01.org/aero/repo/1.5/
+baseurl=https://download.01.org/aero/repo/$releasever/
 gpgcheck=1
 enabled=0

--- a/recipes-support/intel-aero-repo/intel-aero-repo_1.5.bb
+++ b/recipes-support/intel-aero-repo/intel-aero-repo_1.5.bb
@@ -1,15 +1,41 @@
+inherit allarch
+
 SUMMARY = "Intel Aero package repository"
 LICENSE = "MIT"
 LICENSE_PATH = "${S}"
-SRC_URI = "file://intel-aero.repo \
-	   file://LICENSE \
-          "
-
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3da9cfbcb788c80a0384361b4de20420"
+SRC_URI = "file://LICENSE"
 
 S = "${WORKDIR}"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3da9cfbcb788c80a0384361b4de20420"
 
-do_install() {
-        install -d ${D}${sysconfdir}/yum.repos.d
-        install -m 0644 ${WORKDIR}/intel-aero.repo ${D}${sysconfdir}/yum.repos.d/
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+
+REPO_FIELDS = "name baseurl gpgcheck enabled"
+
+name= "Intel Aero"
+baseurl= "https://download.01.org/aero/repo/${DISTRO_VERSION}/"
+gpgcheck= "1"
+enabled= "0"
+
+
+python do_compile () {
+    import shutil    
+    with open(d.expand('${B}/intel-aero.repo'), 'w') as f:
+        f.write('[Main]\n')
+        for field in d.getVar('REPO_FIELDS').split():
+            value = d.getVar(field)
+            if value:
+                f.write('{0}={1}\n'.format(field, value))
 }
+do_compile[vardeps] += "${REPO_FIELDS}"
+
+do_install () {
+        install -d ${D}${sysconfdir}/yum.repos.d
+        install -m 0644 intel-aero.repo ${D}${sysconfdir}/yum.repos.d/
+}
+


### PR DESCRIPTION
#244 

$releasever (along with $arch, $basearch, $uuid) are variables used by yum internally.
We can use this variable to reference the release version. Please find the below link for reference.  
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html