### PR TITLE
camera-streaming-daemon: Enable down-faced camera

### DIFF
--- a/recipes-support/camera-streaming-daemon/camera-streaming-daemon_0.1.bb
+++ b/recipes-support/camera-streaming-daemon/camera-streaming-daemon_0.1.bb
@@ -15,6 +15,8 @@ inherit autotools pythonnative pkgconfig update-rc.d systemd
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
 PACKAGECONFIG[systemd] = "--enable-systemd --with-systemdsystemunitdir=${systemd_unitdir}/system/,--disable-systemd"
 
+EXTRA_OECONF_append = " --enable-aero"
+
 do_compile_prepend () {
     export PYTHONPATH="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/python2.7/site-packages/"
 }

--- a/recipes-support/camera-streaming-daemon/files/main.conf
+++ b/recipes-support/camera-streaming-daemon/files/main.conf
@@ -4,7 +4,7 @@ encoder=vaapih264enc
 converter=autovideoconvert
 
 [v4l2]
-blacklist=video0,video1,video2,video3,video4,video5,video6,video7,video8,video9,video10,video11,video12
+blacklist=video0,video1,video3,video4,video5,video6,video7,video8,video9,video10,video11,video12
 
 [mavlink]
 broadcast_addr=127.0.0.1


### PR DESCRIPTION
It is working fine when playing with QGC and gstreamer but it do not work with VLC. 