### PR TITLE
Add support for MAVROS/DroneCore

### DIFF
--- a/recipes-support/mavlink-router/files/main.conf
+++ b/recipes-support/mavlink-router/files/main.conf
@@ -15,6 +15,11 @@ Address = 192.168.8.255
 Mode = Normal
 Address = 192.168.7.255
 
+# Meant for use by either DroneCore or MAVROS.
+[UdpEndpoint dc_mavros]
+Mode = Normal
+Port = 14540
+
 [UdpEndpoint csd]
 Mode = Normal
 Address = 0.0.0.0


### PR DESCRIPTION
Adding udp port **14540** as en endpoint in mavlink-router conf file to support MAVROS/DroneCore.