### PR TITLE
Workaround for the build failure

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -110,11 +110,8 @@ enable_repo() {
 		sed -i "s/<version>/${version}/" ${IMAGE_ROOTFS}/etc/yum.repos.d/intel-aero.repo
 }
 
-update_firmware() {
-		rm ${IMAGE_ROOTFS}/lib/firmware/iwlwifi-8000C-19.ucode
-}
 
-ROOTFS_POSTPROCESS_COMMAND += "enable_repo; update_firmware;"
+ROOTFS_POSTPROCESS_COMMAND += "enable_repo; "
 
 addtask create_link after do_rootfs before do_image
 

--- a/recipes-support/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-support/linux-firmware/linux-firmware_git.bbappend
@@ -1,0 +1,2 @@
+PACKAGES =+ "${PN}-iwlwifi-8000c"
+FILES_${PN}-iwlwifi-8000c   = "${nonarch_base_libdir}/firmware/iwlwifi-8000C-*.ucode"


### PR DESCRIPTION
As poky/meta completely removed reference of iwlwifi-firmware-8000C, it is
being added in bbappend as workaround. Once poky/meta fixes this issue, this
patch can be reverted.