### PR TITLE
Revert "Workaround for the iwlwifi-firmware-8000C build failure"

### DIFF
--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -110,7 +110,6 @@ enable_repo() {
 		sed -i "s/<version>/${version}/" ${IMAGE_ROOTFS}/etc/yum.repos.d/intel-aero.repo
 }
 
-
 ROOTFS_POSTPROCESS_COMMAND += "enable_repo; "
 
 addtask create_link after do_rootfs before do_image

--- a/recipes-core/images/intel-aero-image.bb
+++ b/recipes-core/images/intel-aero-image.bb
@@ -110,6 +110,7 @@ enable_repo() {
 		sed -i "s/<version>/${version}/" ${IMAGE_ROOTFS}/etc/yum.repos.d/intel-aero.repo
 }
 
+
 ROOTFS_POSTPROCESS_COMMAND += "enable_repo; "
 
 addtask create_link after do_rootfs before do_image

--- a/recipes-support/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-support/linux-firmware/linux-firmware_git.bbappend
@@ -1,2 +1,0 @@
-PACKAGES =+ "${PN}-iwlwifi-8000c"
-FILES_${PN}-iwlwifi-8000c   = "${nonarch_base_libdir}/firmware/iwlwifi-8000C-*.ucode"


### PR DESCRIPTION
This reverts commit 7c28ee349871504223551997403ac6efe5134d9d as upstream poky
has proper fix now.
Removing update_firmware function as firmware v19 is not available any more.